### PR TITLE
3-Redish03

### DIFF
--- a/Redish03/BFS/1697.cpp
+++ b/Redish03/BFS/1697.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+queue<pair<int, int>> q;
+int start, endPoint;
+bool visited[99999999] = {
+    false,
+};
+
+void bfs()
+{
+    while (!q.empty())
+    {
+        int cur_number = q.front().first;
+        int count = q.front().second;
+        q.pop();
+        if (cur_number == endPoint)
+        {
+            cout << count;
+            return;
+        }
+        if (visited[cur_number] || (cur_number < 0 || cur_number > 100001))
+            continue;
+        visited[cur_number] = true;
+        count++;
+        q.push({cur_number - 1, count});
+        q.push({cur_number + 1, count});
+        q.push({cur_number * 2, count});
+    }
+}
+
+int main()
+{
+    cin >> start >> endPoint;
+    q.push({start, 0});
+    bfs();
+}

--- a/Redish03/README.md
+++ b/Redish03/README.md
@@ -3,5 +3,7 @@
 | 차시  |    날짜    | 문제유형 |                          링크                           |                          풀이                           |
 | :---: | :--------: | :------: | :-----------------------------------------------------: | :-----------------------------------------------------: |
 | 1차시 | 2024.01.01 | Dijkstra | [최소비용 구하기](https://www.acmicpc.net/problem/1916) | [#1](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/5) |
+| 2차시 | 2024.01.04 |    DP    |   [정수 삼각형](https://www.acmicpc.net/problem/1932)   | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/6) |
+| 3차시 | 2024.01.07 |   BFS    |    [숨바꼭질](https://www.acmicpc.net/problem/1697)     | [#3](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/5) |
 
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[숨바꼭질](https://www.acmicpc.net/problem/1697) 

## ✔️ 소요된 시간
2h..
사실 거의 다 풀엇는데 메모리 초과로 인한...ㅠ

## ✨ 수도 코드
### 문제 이해
- 수빈이는 현재 `N`에 있고, 동생은 `K`에 있다. 수빈이는 1칸씩 앞, 뒤로 가거나 (+1 또는 -1을 하거나), 순간이동을 통해서 현재 위치의 2배로 이동할 수 있다. 한 칸 씩 이동하거나 순간이동을 할 때마다 1초씩 걸린다.
- 이 때, 수빈이가 동생을 찾을 수 있는 가장 빠른 시간이 몇 초 후인지 구하여라.

### 문제 접근
- 처음에는 +1, -1, * 2 중에 선택하는 그리디 인줄 알았다. 그러나 문제를 풀다 보니 BFS로 귀결되었다. 
- 예제 입력을 보면서 생각을 해보자. 
     - 일단, 입력으로 `5 17` 이 주어지므로, 수빈이의 위치는 5이다.
     - 5에서 수빈이는 다음 행동으로 +1. -1, * 2를 할 수 있다.
     - 그럼 5 다음으로는 10, 4, 6 의 좌표가 될 것이다.
     - 그 다음은 10, 4, 6의 자리에서 20,9,11,8...과 같은 경우의 수가 나온다. 
     - 이런 경우의 수를 쭉 나열 한 것을 그래프 처럼 나타내면 다음과 같이 나타낼 수 있다. 
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/98575563/67bc6843-64d7-4d2b-ba9f-79f5ef7dddd2)

- 그럼 위 그래프를 통해서 문제를 풀어보자.
    - 처음 빼고 다 3개의 하위 노드를 가짐. 
    - 겹치는 숫자 있을 수 있음. 겹치는 숫자들은 할 수 있는 다음 행동으로 같은 값을 가지므로, 중복에 대한 관리를 해줄 필요 있음.
    - `5`는 0초, `10, 4, 6`은 1초, `20, 9, 11, 8, 3, 5, 12, 5, 7` 은 2초로 초에 대한 관리를 할 필요가 있다. 이는 부모 노드에 1초를 더한 값이다.

### 주요 변수
- `q` : <int, int> 형을 담는 큐로, 앞의 first 자리의 int는 숫자, 두 번째 second 자리의 int는 초를 세준다.
- `visited` : 방문 처리. 인덱스에 해당하는 숫자를 확인해준다.
- `start, endPoint` : 각각 시작지점과 끝지점 (endPoint라고 한 이유는,,,end랑 ends가 이미 선언되어있어서 못썼다 ㅋㅋ)

### 메인 로직
``` c++
q.push({start, 0});
while (!q.empty())
    {
        // cur_number은 현재 위치, count는 현재 초이다.
        int cur_number = q.front().first;
        int count = q.front().second;
        q.pop();

        // 현재 위치가 끝지점이라면 출력하고 return
        if (cur_number == endPoint)
        {
            cout << count;
            return;
        }

        // 만약 방문했었거나, 현재의 위치가 범위를 벗어났을 때
        if (visited[cur_number] || (cur_number < 0 || cur_number > 100001))
            continue;

        // 현재 위치 방문 처리
        visited[cur_number] = true;

        // 1초 증가 
        count++;

        // 현재 위치에서 -1을 할 때
        q.push({cur_number - 1, count});

        // 현재 위치에서 +1을 할 때
        q.push({cur_number + 1, count});

        // 현재 위치에서 *2를 할 때
        q.push({cur_number * 2, count});
    }
```
- 맨 처음 수는 0초 걸리지만 시작점을 넣어준다. 즉, {start, 0}을 넣어준다. 
    - 그럼 현재 수 (cur_number)은 5이고, count는 0이다.
    - {5, 0}을 큐에서 빼준다.
    - visited에 false가 저장되어있고, 범위 안의 수이다.
    - 그럼, 방문처리를 해주고, 초를 증가 시킨 후 -1, +1, *2를 한 값인 {4, 1}, {6, 1}, {10, 1}을 큐에 넣어준다.
- 다음은 {4, 1}을 꺼낸다.
    - 그럼 현재 수는 4이고, count는 1이다.
    - visited가 false이고, 현재 수가 범위 안의 수이다.
    - 그럼 visited[4] 를 방문처리 해주고, 초를 증가시킨다.
    - -1, +1, *2 한 수와 2초를 큐에 넣어준다.
- 이런식으로 반복한다.
- 그러다가 `cur_number`가 목표 지점인 17이 되면, 걸린 초를 출력하고 함수를 벗어난다.


### 🎯 트러블 슈팅 (?)
- 방문 처리 와 범위 확인 안해줘서 시간초과 또는 메모리 초과 발생
``` c++
void bfs()
{
    while (true)
    {
        int number = q.front().first;
        int count = q.front().second;

        q.pop();
        if (number == endPoint)
        {
            cout << count;
            return;
        }
        q.push({number - 1, count + 1});
        q.push({number + 1, count + 1});
        q.push({2 * number, count + 1});
    }
}

```
- 방문체크 해줬는데....이러면서 범위를 같이 체크 안해줘서 왜 이게 안되지 이러고 잇엇다...사실 시간을 줄이는 방법을 생각하긴 했는데, 범위를 제한하면 안될 것 같아서 범위검사를 안 넣은것도 있다.

## 📚 토의 해볼만한 내용?
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/98575563/a7acc61a-7786-4f69-83f5-5984df446bf9)
- 메모리가 ㅋㅋㅋㅋㅋㅋ홀리몰리....
- 어케 하면 줄일 수 있을까요???? 제일 큰 문제는 visited 배열의 크기가 99999999 여서인것도 있을것 같은데...
- 또 큐가 쓸데없는 숫자를 너무 많이 넣어서도 있을 것 같고..흠...
