### PR TITLE
7-miniron-v

### DIFF
--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -8,4 +8,5 @@
 | 4차시 | 2024.01.10 |  그리디  | [물병](https://www.acmicpc.net/problem/1052)  | [#14](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/14) |
 | 5차시 | 2024.01.13 |  브루트포스  | [리모컨](https://www.acmicpc.net/problem/1107)  | [#20](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/20) |
 | 6차시 | 2024.01.16 |  DP  | [이친수](https://www.acmicpc.net/problem/2193)  | [#23](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/23) |
+| 7차시 | 2024.01.19 |  수학  | [소수의 연속합](https://www.acmicpc.net/problem/1644)  | [#26](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/26) |
 ---

--- a/miniron-v/수학/1644-소수의 연속합.cpp
+++ b/miniron-v/수학/1644-소수의 연속합.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <vector>
+
+std::vector<bool> is_prime;
+
+void eratosthenes() {
+	for (int i = 2; i < is_prime.size(); i++) {
+		if (is_prime[i] == false) {
+			continue;
+		}
+
+		for (int j = i * 2; j < is_prime.size(); j += i) {
+			is_prime[j] = false;
+		}
+	}
+}
+
+// 다음 소수를 반환, 배열 범위 초과 시 size 반환
+int moveToNextPrime(int i) {
+	for (i++; i < is_prime.size(); i++) {
+		if (is_prime[i] == true) {
+			break;
+		}
+	}
+
+	return i;
+}
+
+int main() {
+	// 입력
+	int n;
+	std::cin >> n;
+
+	// 에라토스테네스의 체 생성
+	is_prime.assign(n + 1, true);
+	eratosthenes();
+
+    // 계산
+	int start = 2, end = 2;
+ 	int sum = 2, count = 0;
+	
+	while (start < is_prime.size() && end < is_prime.size() && start <= end) {
+		if (sum == n) {
+;			count++;
+
+			sum -= start;
+			start = moveToNextPrime(start);
+		}
+
+		else if (sum < n) {
+			end = moveToNextPrime(end);
+			sum += end;
+		}
+
+		else if (sum > n) {
+			sum -= start;
+			start = moveToNextPrime(start);
+		}
+	}
+
+    // 출력
+	std::cout << count;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/1644
1644번: 소수의 연속합
분류: 수학, 정수론, 에라토스테네스의 체

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
30분

## ✨ 문제
하나 이상의 연속된 소수의 합으로 나타낼 수 있는 자연수들이 있다. 몇 가지 자연수의 예를 들어 보면 다음과 같다.

3 : 3 (한 가지)
41 : 2+3+5+7+11+13 = 11+13+17 = 41 (세 가지)
53 : 5+7+11+13+17 = 53 (두 가지)
하지만 연속된 소수의 합으로 나타낼 수 없는 자연수들도 있는데, 20이 그 예이다. 7+13을 계산하면 20이 되기는 하나 7과 13이 연속이 아니기에 적합한 표현이 아니다. 또한 한 소수는 반드시 한 번만 덧셈에 사용될 수 있기 때문에, 3+5+5+7과 같은 표현도 적합하지 않다.

자연수가 주어졌을 때, 이 자연수를 연속된 소수의 합으로 나타낼 수 있는 경우의 수를 구하는 프로그램을 작성하시오.

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
가장 먼저, **어떻게 연속된 부분을 판정하는가**부터 고민해보자.

나는 이 문제를 보고 2-Sum 알고리즘을 떠올렸다. 정렬된 배열에서 두 개의 포인터를 움직여, 올바른 해를 찾는 알고리즘이다.
그리고 설명을 위해 찾다보니, 이 방식이 **투포인터** 알고리즘이라 불리는 것을 알아냈다.
https://ansohxxn.github.io/algorithm/twopointer/

이 문제를 예로 들어보자.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/52f2e3b0-8ee4-4af5-b1ce-cc159b723574)

위처럼 정렬된 소수 배열이 있다고 가정해보자. 처음엔 start와 end 모두 2를 가리키고 있다. sum은 start 이상, end 이하의 **모든 소수를 더한 값**이다.
따라서 지금은 sum이 2다.

이제 sum과 n을 비교해보자. 2는 41에 비해 훨씬 **작은 수**다. 그러니, 수를 조금 더 더해야 하지 않겠는가?
end를 오른쪽으로 한 칸 옮기면, 우린 새로운 수를 더할 수 있다!

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/f3577f82-8116-4481-8cfd-7b68f07b52f9)

그래서 end를 3으로 옮겼다. 이제 sum은 5가 되었다.
하지만 여전히 sum이 n보다 작다. 그러니 계속 end를 이동시켜보자.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/74056604-7485-45fe-97a6-dd283c250218)

end가 13에 도착하니, sum이 정확히 41이 되었다!
만약 Yes/No만 출력하는 문제였다면 여기서 바로 끝났겠지만, **우린 경우의 수를 구해야만 한다.**
그러니 count를 1 증가시키고, 다음 경우의 수를 구해야 한다.

그럼 생각해보자. start가 고정된 상태에선 end를 아무리 옮겨봤자 n이 나오지 않는다. 그러니 start를 한 칸 옮기면 다음 경우의 수를 탐색할 수 있다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/2ac0c5c0-3839-4389-a6ad-f08c1ec293c2)

start는 3이 됐고, sum은 39가 됐다. 이제 다시 sum이 n보다 작아졌으니 end를 옮긴다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/c250ff50-2f94-40fa-bb40-180b70f100cf)

드디어 처음 보는 경우, **sum이 n보다 큰** 경우가 나타났다!
sum이 n을 넘었으니 sum을 줄여야 한다. end를 줄이냐, start를 줄이냐 생각해보면, 큰 고민 없이 start를 옮겨야 함을 알 수 있다. end를 더해서 넘겼으니 end를 줄이면 무한 반복이기도 하고, start가 더 작은 값이니 n에 가까워질 확률이 더 높기 때문이다.
그러니 start를 한 칸 옮겨보자.

여기서 간단하게 정리해보면, start 이상 end 이하의 모든 소수를 더한 값을 sum이라고 할 때
1. sum < n이라면 end를 한 칸 이동 (sum 증가)
2. sum > n이라면 start를 한 칸 이동 (sum 감소)
3. sum == n이라면 count를 세고, start를 이동 (sum 감소)

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/2167fdd0-2909-4304-875a-24386710f21e)

위 과정이 반복되다가 start = 11, end = 17일 때 또다시 41이 되었다. count가 증가되고, 다시 한 칸 옮겨 다음 경우의 수를 탐색해보자.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/be88a122-29ba-4fbf-bc73-5a0f4970bbd1)

먼 미래(?)에, start와 end가 모두 41에 모인 순간 count가 한 번 더 증가했다.
이후 과정대로라면 start는 한 칸 이동해 43이 될 것이다. **start가 end를 넘어선 순간, 프로그램은 종료된다.**

왜 이 탐색의 탈출 조건이 start > end일까?
start가 end를 넘어서는 경우는 두 가지다.
1. start == end이며, 동시에 n인 경우
2. start == end이며, sum이 n보다 큰 경우.

첫 번째 경우의 수를 보면, 이는 **n이 곧 정답인 경우**다. 이후 남은 소수들은 n보다 큰 소수들 뿐이니, **n을 만들 수 없다.**
사실 두 번째 경우의 수도 같은 경우다. 이미 start와 end가 모두 n보다 큰 소수라면, 더 이상 탐색해도 n을 만들 순 없다. 그러니 이 순간 로직을 종료하는 것이다.
- - -
### Q) 그럼, 정렬된 소수 배열만 있다면 문제를 풀 수 있다는 건 알겠는데요, 그 소수 배열은 어떻게 구하나요?
여기에 **에라토스테네스의 체**가 쓰인다.

https://ko.wikipedia.org/wiki/에라토스테네스의_체
에라토스테네스의 체 원리는 위키피디아를 참고하면 쉽게 파악할 수 있다.
2의 배수를 모두 제거하고, 3의 배수를 모두 제거하고, 5의 배수를 모두 제거하고... 이 방법을 반복해 소수만 남기고 제거할 수 있다.

https://velog.io/@max9106/Algorithm-에라토스테네스의-체
코드로 구현하는 건 위 블로그를 참고해, 내 입맛대로 개조시켰다.

여기서 내가 걱정했던 건 **시간복잡도**였다. 최댓값이 4,000,000인 이 문제에서, 너무 오랜 시간이 걸리면 통과할 수 없을 테니까.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/1ccaa0bb-cc7e-430a-9b0b-d8e10dfefceb)

그런데 ChatGPT에게 물어보니, 시간복잡도는 **웬만한 정렬보다 빨랐다.** 그래서 고민없이 구현했다.
```c++
std::vector<bool> is_prime;

void eratosthenes() {
	for (int i = 2; i < is_prime.size(); i++) {
		if (is_prime[i] == false) {
			continue;
		}

		for (int j = i * 2; j < is_prime.size(); j += i) {
			is_prime[j] = false;
		}
	}
}
```
이렇게 걸러낸 후 '새 벡터에 담을까?' 생각했었는데, 배보다 배꼽이 커져서 그만두기로 했다.

설명이 좀 어려울 수 있지만, 외려 코드로 나타내면 깔끔해진다. 전체 코드를 살펴보자.

## 📚 전체 코드
```c++
#include <iostream>
#include <vector>

std::vector<bool> is_prime;

void eratosthenes() {
	for (int i = 2; i < is_prime.size(); i++) {
		if (is_prime[i] == false) {
			continue;
		}

		for (int j = i * 2; j < is_prime.size(); j += i) {
			is_prime[j] = false;
		}
	}
}

// 다음 소수를 반환, 배열 범위 초과 시 size 반환
int moveToNextPrime(int i) {
	for (i++; i < is_prime.size(); i++) {
		if (is_prime[i] == true) {
			break;
		}
	}

	return i;
}

int main() {
	// 입력
	int n;
	std::cin >> n;

	is_prime.assign(n + 1, true);
	// 에라토스테네스의 체 생성
	eratosthenes();

	int start = 2, end = 2;
 	int sum = 2, count = 0;
	
	while (start < is_prime.size() && end < is_prime.size() && start <= end) {
		if (sum == n) {
			count++;

			sum -= start;
			start = moveToNextPrime(start);
		}

		else if (sum < n) {
			end = moveToNextPrime(end);
			sum += end;
		}

		else if (sum > n) {
			sum -= start;
			start = moveToNextPrime(start);
		}
	}

	std::cout << count;
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
에라토스테네스의 체를 알고는 있었지만, 뭔가 비효율적인 느낌이라 안 쓰고 있었다. 그런데 생각보다 효율적인 알고리즘이어서 앞으로 애용해야겠다고 생각했다. 사실 이거 쓰려고 소수 문제 푼 거도 있다.

이걸 1등으로 푼 joeyvalentine님의 코드를 봤는데, 원리는 같은데 세부적인 구현 방법이 많이 차이났다. 이거 원리 알려주실 분 계신가요...?
https://www.acmicpc.net/user/joeyvalentine

전체 사고 과정: https://autumncat.tistory.com/54