### PR TITLE
15-Redish03

### DIFF
--- a/Redish03/DFS/1167.cpp
+++ b/Redish03/DFS/1167.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+vector<vector<pair<int, int>>> tree(100001);
+int max_dist = -99;
+vector<bool> path;
+int max_node = 0;
+
+void dfs(int node, int distance)
+{
+    if (path[node])
+    {
+        return;
+    }
+    if (distance > max_dist)
+    {
+        max_dist = distance;
+        max_node = node;
+    }
+    path[node] = true;
+    for (int i = 0; i < tree[node].size(); i++)
+    {
+        int nnode = tree[node][i].first;
+        int ndist = tree[node][i].second;
+        dfs(nnode, distance + ndist);
+    }
+}
+
+int main()
+{
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    int V;
+    cin >> V;
+    int a, node, dist;
+    path.resize(V + 1, false);
+
+    for (int i = 0; i < V; i++)
+    {
+        cin >> a;
+        while (true)
+        {
+            cin >> node;
+            if (node == -1)
+                break;
+            cin >> dist;
+
+            tree[a].push_back({node, dist});
+        }
+    }
+    dfs(1, 0);
+    path.assign(V + 1, false);
+    dfs(max_node, 0);
+
+    cout << max_dist;
+}

--- a/Redish03/README.md
+++ b/Redish03/README.md
@@ -16,5 +16,6 @@
 | 12차시 | 2024.02.03 |      DP       |      [구간 합 구하기 5](https://www.acmicpc.net/problem/11660)      | [#12](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/47) |
 | 13차시 | 2024.02.06 | Back tracking |          [N과 M(9)](https://www.acmicpc.net/problem/15663)          | [#13](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/52) |
 | 14차시 | 2024.02.12 | KnapSack(DP)  |        [평범한 배낭](https://www.acmicpc.net/problem/12865)         | [#14](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/55) |
+| 15차시 | 2024.02.15 |      DFS      |         [트리의 지름](https://www.acmicpc.net/problem/1167)         | [#14](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/55) |
 
 ---


### PR DESCRIPTION
## 🔗 문제 링크
[트리의 지름](https://www.acmicpc.net/problem/1167)

## ✔️ 소요된 시간
2h

## ✨ 수도 코드
### ❓ 문제 이해
트리의 지름이란, 트리에서 임의의 두 점 사이의 거리 중 가장 긴 것을 말한다. 트리의 지름을 구하여라.

### 🚶 문제 접근
- 처음에는 한 점과 모든 점에 대해서 최소 경로를 찾는 다익스트라 인줄 알았다. 최소 -> 최대로 하면 되지 않을까?라는 안일한 생각을 했다.
- 트리이고 각 노드까지 거리 정보가 담겨있다. 따라서, BFS나 DFS같이 탐색도 생각했는데, BFS 또한 최소 경로에 가까우므로 DFS를 선택했다.

### 풀이
- 트리에는 각 노드 node에 대해서 `<연결된 노드, 그 노드와의 거리>` 가 저장되어있다. 이는 아래와 같다.
``` c++
vector<vector<pair<int, int>>> tree(100001);
tree[node][connected_node] = distance;
```
- `path`에는 방문한 적 있는 노드인지 확인해준다. 인덱스의 번호는 노드의 번호가 된다.
- 트리의 지름은 **임의의 점 두 개** 의 거리를 확인한다. 따라서, 1번 노드 에서 시작해 1번노드에서 최대 거리의 노드인 `max_node`를 구하고, 이 `max_node`에서 다시 시작해 이 점에서 각 노드에 대한 최대 거리를 구한다. 그러면 임의의 점 두 개를 얻을 수 있다. **따라서, DFS를 1->max_node, max_node -> ?로 두 번 동작시키게 된다.**
- `dfs` 함수는 최대 거리를 max_dist에 저장시키고, max_node를 구한다.
``` c++
void dfs(int node, int distance)
{
// 방문한 적 있는 노드라면
    if (path[node])
    {
        return;
    }
// 지금의 경로가 저장되어있는 최대 거리보다 클 경우
    if (distance > max_dist)
    {
        max_dist = distance;
        max_node = node;
    }
// node에 대한 방문 처리
    path[node] = true;

    for (int i = 0; i < tree[node].size(); i++)
    {
        int nnode = tree[node][i].first; // first에는 node와 연결된 노드
        int ndist = tree[node][i].second; // second에는 node와 연결된 노드 사이의 거리가 저장.
        dfs(nnode, distance + ndist); // 연결된 노드와 기존 거리에 node - nnode 사이의 거리를 더해서 재귀 호출
    }
}
```

## 📚 새롭게 알게된 내용
### 질문 및 의문점
- 처음에는 DFS 코드의 for 문 아래와 같이 짰는데..왜 제대로 동작이 안했는지 잘 모르겟습니다
``` c++
    for (int i = 0; i < tree[node].size(); i++)
    {
        int nnode = tree[node][i].first;
        int ndist = tree[node][i].second;
        path[nnode] = true;

        dfs(nnode, distance + ndist);
        path[nnode] = false;
    }
```

### 골 2래서 잔뜩 쫄고 있었지만...생각보다 별거 없을지도 
