### PR TITLE
17-miniron-v

### DIFF
--- a/miniron-v/DP/1699-제곱수의 합.cpp
+++ b/miniron-v/DP/1699-제곱수의 합.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <vector>
+
+int main() {
+	int n;
+	std::cin >> n;
+
+	std::vector<int> dp(n + 1, 0);
+	dp[1] = 1;
+
+	for (int i = 2; i <= n; ++i) {
+		int min_index = i - 1;
+		
+		for (int j = 2; j * j <= i; ++j) {
+			if (dp[i - (j * j)] < dp[min_index]) {
+				min_index = i - (j * j);
+			}
+		}
+
+		dp[i] = dp[min_index] + 1;
+	}
+
+	std::cout << dp[n];
+}

--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -19,4 +19,5 @@
 | 14차시 | 2024.02.11 |  그래프, DP  | [ACM Craft](https://www.acmicpc.net/problem/1005)  | [#53](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/53) |
 | 15차시 | 2024.02.15 |  DP, 큰 수 연산  | [타일링](https://www.acmicpc.net/problem/1793)  | [#56](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/56) |
 | 16차시 | 2024.02.18 |  수학  | [합](https://www.acmicpc.net/problem/1081)  | [#61](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/61) |
+| 17차시 | 2024.02.21 |  DP  | [제곱수의 합](https://www.acmicpc.net/problem/1699)  | [#64](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/64) |
 ---

--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -14,6 +14,9 @@
 | 10차시 | 2024.01.28 |  그래프  | [토마토](https://www.acmicpc.net/problem/7569)  | [#38](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/38) |
 | 번외 - 10 | 2024.01.30 |  그래프  | [하이퍼 토마토](https://www.acmicpc.net/problem/17114)  | [#42](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/42) |
 | 11차시 | 2024.01.31 |  브루트포스  | [감소하는 수](https://www.acmicpc.net/problem/1038)  | [#43](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/43) |
-| 12차시 | 2024.01.31 |  DP  | [점프 점프](https://www.acmicpc.net/problem/11060)  | [#48](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/48) |
-| 13차시 | 2024.01.31 |  DP  | [퇴사 2](https://www.acmicpc.net/problem/15486)  | [#50](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/50) |
+| 12차시 | 2024.02.03 |  DP  | [점프 점프](https://www.acmicpc.net/problem/11060)  | [#48](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/48) |
+| 13차시 | 2024.02.06 |  DP  | [퇴사 2](https://www.acmicpc.net/problem/15486)  | [#50](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/50) |
+| 14차시 | 2024.02.11 |  그래프, DP  | [ACM Craft](https://www.acmicpc.net/problem/1005)  | [#53](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/53) |
+| 15차시 | 2024.02.15 |  DP, 큰 수 연산  | [타일링](https://www.acmicpc.net/problem/1793)  | [#56](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/56) |
+| 16차시 | 2024.02.18 |  수학  | [합](https://www.acmicpc.net/problem/1081)  | [#61](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/61) |
 ---

--- a/miniron-v/수학/1081-합.cpp
+++ b/miniron-v/수학/1081-합.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+
+long long gaussSum(long long k) {
+	if (k % 2 == 0) {
+		return (k / 2) * (k + 1);
+	}
+
+	return ((k + 1) / 2) * k;
+}
+
+long long getSumOfPlace(long long n) {
+	if (n < 1) {
+		return 0;
+	}
+
+	long long answer = gaussSum(n);
+
+	long long d = 10;
+	while ((n / d) > 0) {
+		long long q = n / d;
+		long long r = n % d;
+
+		answer -= 9 * (gaussSum(q - 1) * d + q * (r + 1));
+
+		d *= 10;
+	}
+
+	return answer;
+}
+
+int main() {
+	long long l, u;
+	std::cin >> l >> u;
+
+	std::cout << getSumOfPlace(u) - getSumOfPlace(l - 1);
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/1699
1699번: 제곱수의 합
분류: DP

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
20분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
가장 단순한 형태의 DP. 바텀업 방식으로 손쉽게 풀 수 있다.

DP의 가장 기본적인 구현. 1차원 배열에서 N번 칸의 최솟값을 구할 때 우린 이렇게 구현한다.

```
dp[N]에 한 번에 도달할 수 있는 모든 칸들 중
가장 작은 값을 갖는 칸을 골라
+1한 값을 dp[N]에 저장한다.
```

이번 문제는 특히 **1*1=1**을 원소로 갖기에, **반드시 모든 칸에 1 이상의 값이 적힌다.** (못해도 직전 칸 +1은 되니까)

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/464b1a7e-733e-4756-b042-8ed04fca9997)

N = 11인 경우를 예로 들어보자.
11로 한 번에 점프할 수 있는 인덱스는 무엇이 있을까?
**가장 먼저 10**이 있다. 10 + 1 * 1로, 10의 정답(1 + 9)에 1을 더해 단번에 도달 가능하다.
그 다음은 **7**이다. 7 + 2 * 2로, 7의 답(4 + 1 + 1 + 1)에 4를 더하면 11이 된다.
마지막은 **2**다. 눈치챘겠지만, 이번엔 3 * 3을 더해 11로 점프할 수 있다.

바텀업 방식은 **이전의 모든 칸에 답이 적혀 있는** 상태다. 그러니 위의 표에 따르면
(10을 이루는 최소 항의 개수인) **2개의 항에 하나의 항(1)을 더하거나**(3개의 항)
7을 이루는 **4개의 항에 하나(4)를 더 하거나**(5개의 항)
2을 이루는 **2개의 항에 하나(9)를 더 하거나**(3개의 항). 3가지 방법이 있다.

이 중 11을 이루는 항의 개수 중 최솟값은 3이므로, dp[11]엔 **3이 입력**된다. 또한, 이를 출력하면 N이 11일 때 답이다.

## 📚 전체 코드
```c++
#include <iostream>
#include <vector>

int main() {
	int n;
	std::cin >> n;

	std::vector<int> dp(n + 1, 0);
	dp[1] = 1;

	for (int i = 2; i <= n; ++i) {
		int min_index = i - 1;
		
		for (int j = 2; j * j <= i; ++j) {
			if (dp[i - (j * j)] < dp[min_index]) {
				min_index = i - (j * j);
			}
		}

		dp[i] = dp[min_index] + 1;
	}

	std::cout << dp[n];
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
왜 이렇게 쉬운 거 푸셨냐고 묻는다면... 일찍 일어나야 하는 날이지만 BFS를 풀어보려고 아래 놈을 골랐는데요
https://www.acmicpc.net/problem/2638
집오자마자 풀기 시작했는데 **3시가 넘도록** 못 풀어서 DP로 힐링하며 PR을 썼습니다... 이놈은 언젠가 정복해서 올리겠습니다.