### PR TITLE
18-miniron-v

### DIFF
--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -20,4 +20,5 @@
 | 15차시 | 2024.02.15 |  DP, 큰 수 연산  | [타일링](https://www.acmicpc.net/problem/1793)  | [#56](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/56) |
 | 16차시 | 2024.02.18 |  수학  | [합](https://www.acmicpc.net/problem/1081)  | [#61](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/61) |
 | 17차시 | 2024.02.21 |  DP  | [제곱수의 합](https://www.acmicpc.net/problem/1699)  | [#64](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/64) |
+| 18차시 | 2024.02.24 |  이분 탐색  | [K번째 수](https://www.acmicpc.net/problem/1300)  | [#66](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/66) |
 ---

--- a/miniron-v/이분 탐색/1300-K번째 수.cpp
+++ b/miniron-v/이분 탐색/1300-K번째 수.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+// [n][n] 배열에서 upper 이하 수의 개수를 센다.
+long countNum(long n, long upper) {
+	long count = 0;
+
+	for (long i = 1; i <= n && i <= upper; ++i) {
+		count += std::min(upper / i, n);
+	}
+
+	return count;
+}
+
+int main() {
+	long n, k;
+	std::cin >> n >> k;
+
+	long low = 0, high = k;
+	long mid = 0;
+
+	while (low + 1 < high) {
+		mid = (low + high) / 2;
+		long count = countNum(n, mid);
+
+		if (count < k) {
+			low = mid;
+		}
+
+		else if (count >= k) {
+			high = mid;
+		}
+	}
+
+	std::cout << high;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/1300
1300번: K번째 수
분류: 이분 탐색

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간 30분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
처음엔 [분수찾기](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/9) 문제와 비슷하다고 생각했다.

2차원 배열의 대각선 줄(i와 j가 같은 수들)을 기준으로 대각선을 그으면 항상 **더 작은** 숫자만 나타나니까.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/c6e1be65-f645-4098-b26a-3a763030d2dc)

그래서 이렇게 표를 그려봤는데, 내 생각이 틀렸음을 금세 알 수 있었다. 좌상향이 작은 건 맞지만, 우하향이 항상 크진 않았기에.

그 후 문제 분류가 **이분 탐색**임을 보게 되었고, 금세 로직을 짤 수 있었다.

위 모양처럼은 안 되지만, 어떤 수 **upper보다 작은 수가 몇 개인지**는 쉽게 파악할 수 있다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-5/assets/61517039/ffa3f6ce-3c12-4e05-a74c-1a863a8c0537)

위처럼, 각 행이 구구단처럼 일정하게 증가하기 때문에.

각 행의 upper이하 수의 개수는 **upper / i**(i는 행 번호)로 나타낼 수 있다. 예를 들어 위 사진에서, upper = 6, i = 2라면 **2번째 행에 6이하 수는 6 / 2 = 3개**임이 쉽게 구해진다.

이의 반례로, 이렇게 구한 수의 개수보다 **N이 더 작다면** 개수는 N개가 된다. 그러니 이를 코드로 나타내면

```c++
std::min(upper / i, n);
```

로 나타낼 수 있다.
이를 모든 행에 해주면, **전체 2차원 배열에서** upper 이하 수의 개수를 구할 수 있다.

```c++
// [n][n] 배열에서 upper 이하 수의 개수를 센다.
long countNum(long n, long upper) {
	long count = 0;

	for (long i = 1; i <= n && i <= upper; ++i) {
		count += std::min(upper / i, n);
	}

	return count;
}
```

for문에 2중 조건을 건 건 n과 upper 중 더 작은 값만큼만 돌리기 위해서다. i <= n을 제거해도 문제는 잘 돌아간다. 대신 0을 꽤 많이 더하게 된다.

이후 upper의 값을 이분 탐색을 통해 구하면 문제는 끝이다.

## 📚 전체 코드

```c++
#include <iostream>

// [n][n] 배열에서 upper 이하 수의 개수를 센다.
long countNum(long n, long upper) {
	long count = 0;

	for (long i = 1; i <= n && i <= upper; ++i) {
		count += std::min(upper / i, n);
	}

	return count;
}

int main() {
	long n, k;
	std::cin >> n >> k;

	long low = 0, high = k;
	long mid = 0;

	while (low + 1 < high) {
		mid = (low + high) / 2;
		long count = countNum(n, mid);

		if (count < k) {
			low = mid;
		}

		else if (count >= k) {
			high = mid;
		}
	}

	std::cout << high;
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
태규님이 예전에 [공유기 설치](https://github.com/AlgoLeadMe/AlgoLeadMe-1/pull/120)에서 공유해주셨던 [이분 탐색 헷갈리지 않게 구현하기](https://www.acmicpc.net/blog/view/109)를 읽고난 후, 이분 탐색 구현이 매우 쉬워졌다. 논리도 깔끔하게 정리되었고.

쉬운 문제인데 상당히 시간이 오래 걸렸다. 그 부분은 바로 `long low = 0, high = k;` 여기였다.

처음엔 당연히, `high = n * n + 1`로 두었다. 이것이 최대 값이라고 생각했고, 실제로 모든 반례를 통과했다. (최댓값을 넣었을 때도 통과했다.)

그런데 45%에서 계속 틀렸습니다가 나왔고, `high = k`로 바꾼 후에 **갑자기 성공했다.**

비둘기집 원리처럼 k를 넘는 정답이 안 나오는 건 알았지만, **n * n + 1로 설정했을 때 틀리는** 이유를 알 수 없었다. long long으로도 넣어봤고, 분명 범위 내일텐데.

시간 초과도 아닌 틀렸습니다라서 그나마 의심가는 건 수의 범위 뿐인데... 아직도 잘 모르겠다. N의 범위는 $10^5$ 이하니 끽해봐야 10,000,000,000 정도일 텐데. 이유를 모르겠다.
