### PR TITLE
19-miniron-v

### DIFF
--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -20,4 +20,5 @@
 | 15차시 | 2024.02.15 |  DP, 큰 수 연산  | [타일링](https://www.acmicpc.net/problem/1793)  | [#56](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/56) |
 | 16차시 | 2024.02.18 |  수학  | [합](https://www.acmicpc.net/problem/1081)  | [#61](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/61) |
 | 17차시 | 2024.02.21 |  DP  | [제곱수의 합](https://www.acmicpc.net/problem/1699)  | [#64](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/64) |
+| 18차시 | 2024.02.24 |  이분 탐색  | [K번째 수](https://www.acmicpc.net/problem/1300)  | [#66](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/66) |
 ---

--- a/miniron-v/README.md
+++ b/miniron-v/README.md
@@ -21,4 +21,5 @@
 | 16차시 | 2024.02.18 |  수학  | [합](https://www.acmicpc.net/problem/1081)  | [#61](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/61) |
 | 17차시 | 2024.02.21 |  DP  | [제곱수의 합](https://www.acmicpc.net/problem/1699)  | [#64](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/64) |
 | 18차시 | 2024.02.24 |  이분 탐색  | [K번째 수](https://www.acmicpc.net/problem/1300)  | [#66](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/66) |
+| 19차시 | 2024.02.27 |  다익스트라  | [최단경로](https://www.acmicpc.net/problem/1753)  | [#70](https://github.com/AlgoLeadMe/AlgoLeadMe-5/pull/70) |
 ---

--- a/miniron-v/다익스트라/1753-최단경로.cpp
+++ b/miniron-v/다익스트라/1753-최단경로.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+const int INF = 3000001;
+
+std::vector<int> dijkstra(int start, int n, std::vector<std::vector<std::pair<int, int>>>& graph) {
+	std::vector<int> min_weight(n + 1, INF);
+	std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int>>, std::greater<std::pair<int, int>>> pq;
+
+	min_weight[start] = 0;
+	pq.push({ 0, start });
+
+	while (pq.empty() == false) {
+		int cur_weight = pq.top().first;
+		int cur_node = pq.top().second;
+		pq.pop();
+
+		for (auto& pair : graph[cur_node]) {
+			int next_node = pair.first;
+			int next_weight = cur_weight + pair.second;
+
+			if (next_weight < min_weight[next_node]) {
+				min_weight[next_node] = next_weight;
+				pq.push({ next_weight, next_node});
+			}
+		}
+	}
+
+	return min_weight;
+}
+
+int main() {
+	// 입력
+	int V, E, start;
+	std::cin >> V >> E >> start;
+
+	std::vector<std::vector<std::pair<int, int>>> graph(V + 1);
+	for (int i = 0; i < E; ++i) {
+		int u, v, w;
+		std::cin >> u >> v >> w;
+
+		graph[u].push_back({v, w});
+	}
+	
+	// 계산
+	std::vector<int> min_weight = dijkstra(start, V, graph);
+
+	// 출력
+	for (int i = 1; i < min_weight.size(); ++i) {
+		if (min_weight[i] == INF) {
+			std::cout << "INF\n";
+			continue;
+		}
+
+		std::cout << min_weight[i] << "\n";
+	}
+}

--- a/miniron-v/이분 탐색/1300-K번째 수.cpp
+++ b/miniron-v/이분 탐색/1300-K번째 수.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+// [n][n] 배열에서 upper 이하 수의 개수를 센다.
+long countNum(long n, long upper) {
+	long count = 0;
+
+	for (long i = 1; i <= n && i <= upper; ++i) {
+		count += std::min(upper / i, n);
+	}
+
+	return count;
+}
+
+int main() {
+	long n, k;
+	std::cin >> n >> k;
+
+	long low = 0, high = k;
+	long mid = 0;
+
+	while (low + 1 < high) {
+		mid = (low + high) / 2;
+		long count = countNum(n, mid);
+
+		if (count < k) {
+			low = mid;
+		}
+
+		else if (count >= k) {
+			high = mid;
+		}
+	}
+
+	std::cout << high;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/1753
1753번: 최단경로
분류: 그래프, 다익스트라(데이크스트라)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
다익스트라를 제대로 다루지 못 해서, 블로그를 보며 구현해봤습니다.

https://velog.io/@717lumos/알고리즘-다익스트라Dijkstra-알고리즘
https://suyeon96.tistory.com/31

이 두 블로그를 참고해, 우선순위 큐 방식으로 다익스트라를 구현했습니다.

## 📚 전체 코드
```c++
#include <iostream>
#include <vector>
#include <queue>

const int INF = 3000001;

std::vector<int> dijkstra(int start, int n, std::vector<std::vector<std::pair<int, int>>>& graph) {
	std::vector<int> min_weight(n + 1, INF);
	std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int>>, std::greater<std::pair<int, int>>> pq;

	min_weight[start] = 0;
	pq.push({ 0, start });

	while (pq.empty() == false) {
		int cur_weight = pq.top().first;
		int cur_node = pq.top().second;
		pq.pop();

		for (auto& pair : graph[cur_node]) {
			int next_node = pair.first;
			int next_weight = cur_weight + pair.second;

			if (next_weight < min_weight[next_node]) {
				min_weight[next_node] = next_weight;
				pq.push({ next_weight, next_node});
			}
		}
	}

	return min_weight;
}

int main() {
	// 입력
	int V, E, start;
	std::cin >> V >> E >> start;

	std::vector<std::vector<std::pair<int, int>>> graph(V + 1);
	for (int i = 0; i < E; ++i) {
		int u, v, w;
		std::cin >> u >> v >> w;

		graph[u].push_back({v, w});
	}
	
	// 계산
	std::vector<int> min_weight = dijkstra(start, V, graph);

	// 출력
	for (int i = 1; i < min_weight.size(); ++i) {
		if (min_weight[i] == INF) {
			std::cout << "INF\n";
			continue;
		}

		std::cout << min_weight[i] << "\n";
	}
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
C++에서 pair를 만들 때 `std::make_pair(A, B);`를 쓰지 않고 `{A, B}`만 해도 페어가 만들어진다. (버전 낮아서 안 되는 줄 알았는데 신세계)

추가로 { 가중치, 노드 }로 넣으면 성공, { 노드, 가중치 }로 넣으면 **시간 초과**가 떴는데, pq에 커스텀 함수를 쓰지 않고 `greater<std::pair<int, int>>`를 썼기 때문으로 보인다. 내림차순 정렬해야 최솟값이 나가는 걸보면, 우선순위 큐의 pop이 뒤에서 일어나는 듯.

`greater<std::pair<int, int>>`로 int형처럼 내림차순 정렬이 가능하다. 이때 비교 기준은 first다.